### PR TITLE
add integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ TOPMODS
 TestSet*
 *.png
 *.MOV
+__pycache__

--- a/integration-scripts/INTEGRATION/arg_summary.txt
+++ b/integration-scripts/INTEGRATION/arg_summary.txt
@@ -1,0 +1,28 @@
+[             model_type]                             BN_CNN_3D_DO
+[                   data]                              glued_32_32
+[               features]                             ['hr', 'rr']
+[                    csv]                        WPCC_new-dist.csv
+[                    qbc]                                     None
+[             batch_size]                                        5
+[                 epochs]                                        1
+[             output_dir]          integration-scripts/INTEGRATION
+[              input_dir]          integration-scripts/INTEGRATION
+[         rotation_range]                                       90
+[      width_shift_range]                                      0.5
+[     height_shift_range]                                      0.5
+[             zoom_range]                                      0.5
+[ brightness_range_local]                                     None
+[brightness_range_global]                               [0.1, 1.0]
+[            shear_range]                                      0.0
+[          vertical_flip]                                     True
+[        horizontal_flip]                                     True
+[           greyscale_on]                                     True
+[            redscale_on]                                    False
+[        steps_per_epoch]                                        3
+[             dimensions]                                 [32, 32]
+[                  kfold]                                        4
+[          num_val_clips]                                       15
+[                   loss]                       mean_squared_error
+[         early_stopping]                                       18
+[        sequence_length]                                       90
+[       integration_test]                                     True

--- a/integration-scripts/install_it
+++ b/integration-scripts/install_it
@@ -1,0 +1,5 @@
+#!/bin/sh
+INTEGRATION_DIR=integration-scripts
+
+pip install --upgrade ./src/we_panic_utils >> $INTEGRATION_DIR/integration.log
+exit $?

--- a/integration-scripts/integration.test
+++ b/integration-scripts/integration.test
@@ -1,0 +1,29 @@
+#!/bin/sh
+INTEGRATION_DIR=integration-scripts
+rm -r $INTEGRATION_DIR/INTEGRATION $INTEGRATION_DIR/integration.log
+
+test_outputs() {
+    command=$1
+    pass=$2
+
+    echo $1 | sh
+    result=$?
+
+    if [ $result -eq $2 ]; then
+        echo "[PASS] $1"
+    else
+        echo "[FAIL] $1"
+    fi
+
+    return $result
+}
+
+run() {
+    echo "[RUN] $1"
+    echo $1 | sh
+}
+
+test_outputs "python $INTEGRATION_DIR/test.py pass" 0 
+test_outputs "python $INTEGRATION_DIR/test.py fail" 1 
+test_outputs "./$INTEGRATION_DIR/install_it" 0
+test_outputs "./$INTEGRATION_DIR/test_it" 0  

--- a/integration-scripts/test.py
+++ b/integration-scripts/test.py
@@ -1,0 +1,8 @@
+import sys
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "pass":
+            sys.exit(0) # pass code
+        else:
+            sys.exit(1) 

--- a/integration-scripts/test_it
+++ b/integration-scripts/test_it
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+#########################################
+##  INTEGRATION TEST -- MODEL TESTING  ##
+#########################################
+# This is an integration script, it checks the general software functionality
+# Meaning it verifies it is functioning properly at the macro level.
+# ------------------------
+
+
+## script for runs on the cloud
+INTEGRATION_DIR="integration-scripts"
+
+test_outputs() {
+    command=$1
+    pass=$2
+
+    echo $1 | sh
+    result=$?
+
+    if [ $result -eq $2 ]; then
+        echo "[PASS] $1"
+    else
+        echo "[FAIL] $1"
+    fi
+
+    return $result
+}
+
+epochs=1
+steps_per_epoch=3
+batch_size=5
+
+
+test_outputs "python src/run_model.py BN_CNN_3D_DO glued_32_32 \
+--features hr rr \
+--csv WPCC_new-dist.csv \
+--output_dir integration-scripts/INTEGRATION \
+--epochs $epochs \
+--dimensions 32 32 \
+--steps_per_epoch $steps_per_epoch \
+--batch_size $batch_size \
+--greyscale_on \
+--kfold 4 \
+--num_val_clips 15 \
+--early_stopping 18 \
+--loss mean_squared_error \
+--sequence_length 90 \
+--vertical_flip \
+--horizontal_flip \
+--rotation_range 90 \
+--height_shift_range 0.5 \
+--width_shift_range 0.5 \
+--zoom_range 0.5 \
+--brightness_range_global 0.1 1.0 \
+--integration-test" 0 >> $INTEGRATION_DIR/integration.log
+
+if [ $? -eq 0 ]; then
+    exit 0
+else
+    exit 1
+fi

--- a/spatial_average.py
+++ b/spatial_average.py
@@ -1,0 +1,36 @@
+import numpy as np
+import process_mov as pm
+import matplotlib.pyplot as plt
+from argparse import ArgumentParser
+
+def arguments():
+    parser = ArgumentParser(description='condense a sequence')
+    parser.add_argument('movs',
+                        help='list of .mov files',
+                        nargs='+',
+                        type=pm.mov)
+
+    #parser.add_argument('--output-file','-o',
+    #                    dest='output',
+    #                    help='path to output file (default to stdout)',
+    #                    type=pm.csv,
+    #                    default='default')
+    
+    return parser
+
+def spatial_avg(frame):
+    return np.mean(np.ravel(frame))
+
+if __name__ == '__main__':
+    args = arguments().parse_args() 
+    for mov in args.movs:
+        gen = pm.frame_generator(mov, 
+                                nosubsamp=True,
+                                preprocs=[pm.resize, pm.normalize, spatial_avg])
+       
+        ts = list(gen)
+        plt.plot(ts, marker='o', label=mov)
+        plt.xlabel('Frame #')
+        plt.ylabel('Spatial average')
+    plt.legend()
+    plt.show()

--- a/src/run_model.py
+++ b/src/run_model.py
@@ -4,8 +4,7 @@ command line app for train/testing models.
 
 # inter library imports
 import argparse
-import sys
-import os
+import sys, os
 import time
 from sklearn.preprocessing import MinMaxScaler
 import numpy as np
@@ -200,6 +199,11 @@ def parse_input():
                         help='sequence size for feeding the DNN',
                         default=60,
                         type=int)
+
+    parser.add_argument('--integration-test', dest='integration_test',
+                        help='run the integration test',
+                        default=False,
+                        action='store_true')
     
     return parser
 
@@ -473,10 +477,17 @@ if __name__ == "__main__":
                       |__________________________________"""	
     print(start_banner,sep='')
     start = time.time()
-    engine.run()
+    
+    if not args.integration_test:
+        engine.run()
+    else:
+        sys.exit(0)
+
     end = time.time()
     total = (end - start) / 60
 
     if args.kfold:
         with open(os.path.join(args.output_dir, "time.txt"), 'w') as t:
             t.write(str(total))
+
+    sys.exit(0)

--- a/src/we_panic_utils/we_panic_utils/nn/engine.py
+++ b/src/we_panic_utils/we_panic_utils/nn/engine.py
@@ -364,7 +364,8 @@ class Engine():
                                      callbacks=callbacks,
                                      validation_data=vgen,
                                      validation_steps=vsteps,
-                                     workers=4)
+                                     workers=1,
+                                     use_multiprocessing=False)
             
             # record predictive acc and loss
             #pred = self.model.predict_generator(vgen, vsteps)


### PR DESCRIPTION
Added an integration test in order to verify the user facing functionalities are at least superficially functional and working. 

The integration test found in integration-scripts carries out the test. Any further integrating scripts should be added to the `integration-scripts/integration.test` script. 

Currently covered tests are:
- pip install
- testing a model via `run_model.py`